### PR TITLE
#3 - Don't expose namespace id

### DIFF
--- a/src/main/java/de/dataelementhub/model/dto/element/section/Identification.java
+++ b/src/main/java/de/dataelementhub/model/dto/element/section/Identification.java
@@ -1,5 +1,6 @@
 package de.dataelementhub.model.dto.element.section;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dataelementhub.dal.jooq.enums.ElementType;
 import de.dataelementhub.dal.jooq.enums.Status;
@@ -13,6 +14,7 @@ public class Identification implements Serializable {
 
   private String urn;
   private String namespaceUrn;
+  @JsonIgnore
   private Integer namespaceId;
   private ElementType elementType;
   private Integer identifier;


### PR DESCRIPTION
**What's in the PR**
* identification section of elements no longer contains namespace id

**How to test manually**
* create any element or namespace
* get that element (or any other previously existing element)
* the identification section should no longer contain the namespace id
