### PR TITLE
#5 - Change accept-language handling

### DIFF
--- a/src/main/java/de/dataelementhub/model/dto/element/Element.java
+++ b/src/main/java/de/dataelementhub/model/dto/element/Element.java
@@ -6,7 +6,7 @@ import de.dataelementhub.model.dto.element.section.Definition;
 import de.dataelementhub.model.dto.element.section.Identification;
 import de.dataelementhub.model.dto.element.section.Slot;
 import java.io.Serializable;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
@@ -21,53 +21,55 @@ public class Element implements Serializable {
 
   private Identification identification;
   private List<Definition> definitions;
-  private Definition definition;
   private List<Slot> slots;
 
   /**
-   * Limit the amount of definitions to 1.
-   * Check which of the wanted languages is present and keep that one. If none of those is present,
-   * return the first one.
+   * Filter definitions to only contain the requested languages.
    */
   public void applyLanguageFilter(String languages) {
     if (languages == null || languages.isEmpty()) {
       return;
     }
-    List<Locale> locales = LanguageRange.parse(languages).stream().sorted(
-        Comparator.comparing(LanguageRange::getWeight).reversed())
+    List<Locale> locales = LanguageRange.parse(languages).stream()
         .map(range -> new Locale(range.getRange())).collect(
             Collectors.toList());
 
-    Definition preferredDefinition = null;
-    for (Locale locale : locales) {
-      String language;
-      try {
-        language = locale.getLanguage().split("-")[0];
-      } catch (Exception e) {
-        language = locale.getLanguage();
-      }
+    List<String> requestedLanguages = locales.stream()
+        .map(locale -> {
+          String language;
+          try {
+            language = locale.getLanguage().split("-")[0].toLowerCase();
+          } catch (Exception e) {
+            language = locale.getLanguage().toLowerCase();
+          }
+          return language;
+        })
+        .collect(Collectors.toList());
 
-      // If the wildcard symbol is next in line, leave the for loop and return the first language
-      // found.
-      if (language.equals("*")) {
-        break;
-      }
-
-      // Variable used in lambda expression should be final or effectively final
-      final String finalLanguage = language;
-      preferredDefinition = definitions.stream()
-          .filter(d -> d.getLanguage().equalsIgnoreCase(finalLanguage))
-          .findFirst().orElse(null);
-      if (preferredDefinition != null) {
-        setDefinition(preferredDefinition);
-        break;
-      }
+    // If requested languages contains wildcard character - don't change anything
+    if (requestedLanguages.contains("*")) {
+      return;
     }
 
-    // If none of the requested languages was found, keep the first preferredDefinition instead
-    if (preferredDefinition == null) {
-      setDefinition(definitions.get(0));
+    List<String> availableLanguages = definitions.stream()
+        .map(def -> def.getLanguage().toLowerCase())
+        .collect(Collectors.toList());
+
+    availableLanguages.retainAll(requestedLanguages);
+
+    // If no matching languages are found - don't change anything
+    if (availableLanguages.isEmpty()) {
+      return;
     }
-    definitions = null;
+
+    List<Definition> filteredDefinitions = new ArrayList<>();
+
+    definitions.forEach(def -> {
+      if (availableLanguages.contains(def.getLanguage())) {
+        filteredDefinitions.add(def);
+      }
+    });
+
+    setDefinitions(filteredDefinitions);
   }
 }

--- a/src/main/java/de/dataelementhub/model/dto/listviews/DataElementGroupMember.java
+++ b/src/main/java/de/dataelementhub/model/dto/listviews/DataElementGroupMember.java
@@ -18,7 +18,6 @@ import lombok.NoArgsConstructor;
 public class DataElementGroupMember {
   private String urn;
   private List<Definition> definitions;
-  private Definition definition;
 
   /**
    * Construct a listview dto of dataElementGroup member from an element.
@@ -27,7 +26,6 @@ public class DataElementGroupMember {
   public DataElementGroupMember(Element element) {
     this.urn = element.getIdentification().getUrn();
     this.definitions = element.getDefinitions();
-    this.definition = element.getDefinition();
   }
 }
 

--- a/src/main/java/de/dataelementhub/model/dto/listviews/Namespace.java
+++ b/src/main/java/de/dataelementhub/model/dto/listviews/Namespace.java
@@ -20,7 +20,6 @@ public class Namespace {
   private String urn;
   private int identifier;
   private List<Definition> definitions;
-  private Definition definition;
   private int revision;
   private Status status;
 
@@ -34,7 +33,6 @@ public class Namespace {
     this.revision = fullNamespace.getIdentification().getRevision();
     this.status = fullNamespace.getIdentification().getStatus();
     this.definitions = fullNamespace.getDefinitions();
-    this.definition = fullNamespace.getDefinition();
   }
 
 }


### PR DESCRIPTION
**What's in the PR**
* remove "definition" entry from elements, keeping only the list of defintions
* return all requested (and found) languages for an element, not just the one with the highest quality weight
* if no requested language is found, return all languages
* if a requested language is not found (but others are), simply omit this entry (do not send an "empty" definition)

**How to test manually**
* ~~decide whether it is really better to create and insert a definition object with null values if a language is not found. If it is still required, this PR has to be changed~~
* if it is agreed upon to just skip non-available definitions - go on
* request elements and set the accept-language header to valid entries and see if the result matches your expectation (or better if it matches what is described in the corresponding issue)
