### PR TITLE
#63 - Retrieving path of an element does not return full path

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
@@ -100,13 +100,16 @@ public class ElementPathHandler {
    * Return true if all paths are completed and reached the namespace otherwise return false.
    */
   public static boolean pathsCompleted(List<List<String>> paths) {
+
+    int completedPaths = 0;
+
     for (List<String> path : paths) {
       if (path.stream().anyMatch(n ->
           n.toUpperCase().contains(ElementType.NAMESPACE.getLiteral()))) {
-        return true;
+        ++completedPaths;
       }
     }
-    return false;
+    return completedPaths == paths.size();
   }
 
   /**


### PR DESCRIPTION
**What's in the PR**
* When checking if all paths are completed, do not return true if the first namespace is found but check all paths if they terminate with a namespace

**How to test manually**
* Check if the problem from the bug report is gone
