### PR TITLE
#69 - Don't allow released dataelementgroups with draft dataelements

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
@@ -50,8 +50,17 @@ public class DataElementGroupHandler extends ElementHandler {
     List<Element> members = ElementHandler
         .fetchByUrns(ctx, userId, dataElementGroup.getMembers().stream().map(Member::getElementUrn)
             .collect(toList()));
+
     if (members.size() != dataElementGroup.getMembers().size()) {
       throw new IllegalArgumentException();
+    }
+
+    if (dataElementGroup.getIdentification().getStatus() == Status.RELEASED) {
+      if (members.stream().anyMatch(m -> m.getIdentification().getStatus() == Status.DRAFT
+          || m.getIdentification().getStatus() == Status.STAGED)) {
+        throw new IllegalArgumentException(
+            "Released DataelementGroup may not contain draft or staged members.");
+      }
     }
 
     final boolean autoCommit = CtxUtil.disableAutoCommit(ctx);

--- a/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
@@ -54,6 +54,14 @@ public class RecordHandler extends ElementHandler {
       throw new IllegalArgumentException();
     }
 
+    if (record.getIdentification().getStatus() == Status.RELEASED) {
+      if (members.stream().anyMatch(m -> m.getIdentification().getStatus() == Status.DRAFT
+          || m.getIdentification().getStatus() == Status.STAGED)) {
+        throw new IllegalArgumentException(
+            "Released Record may not contain draft or staged members.");
+      }
+    }
+
     final boolean autoCommit = CtxUtil.disableAutoCommit(ctx);
     de.dataelementhub.dal.jooq.tables.pojos.Element element =
         new de.dataelementhub.dal.jooq.tables.pojos.Element();


### PR DESCRIPTION
**What's in the PR**
* When creating dataelement groups or records with status RELEASED, check if none of the members are drafts or staged

**How to test manually**
* Create a draft dataelement
* Try to create a released dataelementgroup, containing the dataelement from above. this should fail
* Also try if creating a draft dataelementgroup with this element still works as intended
* And try if creating a released dataelementgroup with released elements still works
