### PR TITLE
#71 - fix update members for all parent elements

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
@@ -112,6 +112,16 @@ public class DataElementGroupHandler extends ElementHandler {
   public static Identification updateMembers(CloseableDSLContext ctx, int userId,
       ScopedIdentifier scopedIdentifier) {
     Identification identification = IdentificationHandler.convert(ctx, scopedIdentifier);
+
+    for (Member member : MemberHandler.get(ctx, identification)) {
+      if (member.getElementUrn().contains("dataelementgroup") || member.getElementUrn()
+          .contains("record")) {
+        ScopedIdentifier memberScopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx,
+            member.getElementUrn());
+        updateMembers(ctx, userId, memberScopedIdentifier);
+      }
+    }
+
     if (MemberHandler.newMemberVersionExists(ctx, scopedIdentifier)) {
       DataElementGroup dataElementGroup = get(ctx, userId, identification);
       if (dataElementGroup.getIdentification().getStatus() != Status.DRAFT) {

--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
@@ -112,8 +112,8 @@ public class DataElementGroupHandler extends ElementHandler {
   public static Identification updateMembers(CloseableDSLContext ctx, int userId,
       ScopedIdentifier scopedIdentifier) {
     Identification identification = IdentificationHandler.convert(ctx, scopedIdentifier);
-    DataElementGroup dataElementGroup = get(ctx, userId, identification);
     if (MemberHandler.newMemberVersionExists(ctx, scopedIdentifier)) {
+      DataElementGroup dataElementGroup = get(ctx, userId, identification);
       if (dataElementGroup.getIdentification().getStatus() != Status.DRAFT) {
         ScopedIdentifier newsScopedIdentifier =
             IdentificationHandler.update(ctx, userId, identification,
@@ -127,6 +127,6 @@ public class DataElementGroupHandler extends ElementHandler {
       ScopedIdentifier si = create(ctx, userId, dataElementGroup);
       MemberHandler.updateMembers(ctx, si);
     }
-    return dataElementGroup.getIdentification();
+    return identification;
   }
 }

--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
@@ -18,11 +18,13 @@ import de.dataelementhub.model.handler.element.section.MemberHandler;
 import de.dataelementhub.model.handler.element.section.SlotHandler;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.CloseableDSLContext;
 
 /**
  * Dataelement Group Handler.
  */
+@Slf4j
 public class DataElementGroupHandler extends ElementHandler {
 
   /**
@@ -167,9 +169,13 @@ public class DataElementGroupHandler extends ElementHandler {
         dataElementGroup.getIdentification()
             .setNamespaceId(scopedIdentifier.getNamespaceId());
       }
-      delete(ctx, userId, identification.getUrn());
-      ScopedIdentifier si = create(ctx, userId, dataElementGroup);
-      MemberHandler.updateMembers(ctx, si);
+      try {
+        delete(ctx, userId, identification.getUrn());
+        ScopedIdentifier si = create(ctx, userId, dataElementGroup);
+        MemberHandler.updateMembers(ctx, si);
+      } catch (IllegalStateException e) {
+        log.debug("No need to delete already outdated element.");
+      }
     }
     return identification;
   }

--- a/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
@@ -116,8 +116,8 @@ public class RecordHandler extends ElementHandler {
   public static Identification updateMembers(CloseableDSLContext ctx, int userId,
       ScopedIdentifier scopedIdentifier) {
     Identification identification = IdentificationHandler.convert(ctx, scopedIdentifier);
-    Record record = get(ctx, userId, identification);
     if (MemberHandler.newMemberVersionExists(ctx, scopedIdentifier)) {
+      Record record = get(ctx, userId, identification);
       if (record.getIdentification().getStatus() != Status.DRAFT) {
         ScopedIdentifier newsScopedIdentifier =
             IdentificationHandler.update(ctx, userId, identification,
@@ -131,6 +131,6 @@ public class RecordHandler extends ElementHandler {
       ScopedIdentifier si = create(ctx, userId, record);
       MemberHandler.updateMembers(ctx, si);
     }
-    return record.getIdentification();
+    return identification;
   }
 }

--- a/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
@@ -18,11 +18,13 @@ import de.dataelementhub.model.handler.element.section.MemberHandler;
 import de.dataelementhub.model.handler.element.section.SlotHandler;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.CloseableDSLContext;
 
 /**
  * Record Handler.
  */
+@Slf4j
 public class RecordHandler extends ElementHandler {
 
   /**
@@ -158,9 +160,13 @@ public class RecordHandler extends ElementHandler {
         record.getIdentification()
             .setNamespaceId(scopedIdentifier.getNamespaceId());
       }
-      delete(ctx, userId, identification.getUrn());
-      ScopedIdentifier si = create(ctx, userId, record);
-      MemberHandler.updateMembers(ctx, si);
+      try {
+        delete(ctx, userId, identification.getUrn());
+        ScopedIdentifier si = create(ctx, userId, record);
+        MemberHandler.updateMembers(ctx, si);
+      } catch (IllegalStateException e) {
+        log.debug("No need to delete already outdated element.");
+      }
     }
     return identification;
   }


### PR DESCRIPTION
**What's in the PR**
* Update Members should now correctly update ALL descendants, not only direct children
* Close #71 

**How to test manually**
* see the issue description and check if the behaviour is as desired
