### PR TITLE
#76 - error handling in get element paths method

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/ElementPathHandler.java
@@ -147,12 +147,16 @@ public class ElementPathHandler {
    */
   public static List<ScopedIdentifier> getParentScopedIdentifiers(
       CloseableDSLContext ctx, String urn) {
+    ScopedIdentifier scopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx, urn);
+    if (scopedIdentifier == null) {
+      throw new NoSuchElementException("Element not found: " + urn);
+    }
     return ctx.select()
         .from(SCOPED_IDENTIFIER_HIERARCHY)
         .leftJoin(SCOPED_IDENTIFIER)
         .on(SCOPED_IDENTIFIER.ID.eq(SCOPED_IDENTIFIER_HIERARCHY.SUPER_ID))
         .where(SCOPED_IDENTIFIER_HIERARCHY.SUB_ID
-            .eq(IdentificationHandler.getScopedIdentifier(ctx, urn).getId()))
+            .eq(scopedIdentifier.getId()))
         .fetchInto(ScopedIdentifier.class);
   }
 }

--- a/src/main/java/de/dataelementhub/model/service/ElementService.java
+++ b/src/main/java/de/dataelementhub/model/service/ElementService.java
@@ -323,9 +323,6 @@ public class ElementService {
   public List<List<SimplifiedElementIdentification>> getElementPaths(
       CloseableDSLContext ctx, int userId, String urn, String languages)
       throws IllegalArgumentException, IllegalStateException {
-    if (IdentificationHandler.getScopedIdentifier(ctx, urn).getStatus() == Status.OUTDATED) {
-      throw new IllegalStateException(urn + " is OUTDATED.");
-    }
     return ElementPathHandler.getElementPaths(ctx, userId, urn, languages);
   }
 }

--- a/src/main/java/de/dataelementhub/model/service/ElementService.java
+++ b/src/main/java/de/dataelementhub/model/service/ElementService.java
@@ -321,8 +321,7 @@ public class ElementService {
    * Get all available paths for a given element.
    */
   public List<List<SimplifiedElementIdentification>> getElementPaths(
-      CloseableDSLContext ctx, int userId, String urn, String languages)
-      throws IllegalArgumentException, IllegalStateException {
+      CloseableDSLContext ctx, int userId, String urn, String languages) {
     return ElementPathHandler.getElementPaths(ctx, userId, urn, languages);
   }
 }


### PR DESCRIPTION
**What's in the PR**
* when trying to get the paths for an invalid urn, throw a NoSuchElementException
* close #76 

**How to test manually**
* try to call GET .../{urn}/paths for a urn that does not exist in your dehub. you should now get 404 instead of 500
