### PR TITLE
#80 - Updating draft dataelementgroups fails

### DIFF
--- a/src/main/java/de/dataelementhub/model/dto/element/section/Member.java
+++ b/src/main/java/de/dataelementhub/model/dto/element/section/Member.java
@@ -3,18 +3,35 @@ package de.dataelementhub.model.dto.element.section;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dataelementhub.dal.jooq.enums.Status;
 import java.io.Serializable;
+import java.util.Objects;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
  * Member DTO.
  */
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
 public class Member implements Serializable {
 
   private String elementUrn;
   private Status status;
   private Integer order;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Member member = (Member) o;
+    return Objects.equals(elementUrn, member.elementUrn) && Objects.equals(order,
+        member.order);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(elementUrn, order);
+  }
 }

--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementGroupHandler.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toList;
 import de.dataelementhub.dal.jooq.enums.ElementType;
 import de.dataelementhub.dal.jooq.enums.Status;
 import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifier;
-import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifierHierarchy;
 import de.dataelementhub.dal.jooq.tables.records.IdentifiedElementRecord;
 import de.dataelementhub.model.CtxUtil;
 import de.dataelementhub.model.dto.element.DataElementGroup;
@@ -95,16 +94,8 @@ public class DataElementGroupHandler extends ElementHandler {
       DataElementGroup dataElementGroup, DataElementGroup previousDataElementGroup)
       throws IllegalAccessException {
 
-    List<ScopedIdentifierHierarchy> scopedIdentifierHierarchyList = null;
-    final ScopedIdentifier previousScopedIdentifier;
-
     //update scopedIdentifier if status != DRAFT
-    if (previousDataElementGroup.getIdentification().getStatus() == Status.DRAFT) {
-      previousScopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx,
-          previousDataElementGroup.getIdentification().getUrn());
-      scopedIdentifierHierarchyList
-          = MemberHandler.getHierarchyEntries(ctx, previousScopedIdentifier);
-    } else {
+    if (previousDataElementGroup.getIdentification().getStatus() != Status.DRAFT) {
       ScopedIdentifier scopedIdentifier =
           IdentificationHandler.update(ctx, userId, dataElementGroup.getIdentification(),
               ElementHandler.getIdentifiedElementRecord(ctx, dataElementGroup.getIdentification())
@@ -114,25 +105,10 @@ public class DataElementGroupHandler extends ElementHandler {
       dataElementGroup.getIdentification().setNamespaceId(
           IdentificationHandler.getScopedIdentifier(ctx,
               previousDataElementGroup.getIdentification().getUrn()).getNamespaceId());
-      previousScopedIdentifier = null;
     }
 
     delete(ctx, userId, previousDataElementGroup.getIdentification().getUrn());
     create(ctx, userId, dataElementGroup);
-
-    if (scopedIdentifierHierarchyList != null) {
-      ScopedIdentifier newScopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx,
-          dataElementGroup.getIdentification().getUrn());
-      scopedIdentifierHierarchyList.forEach(sih -> {
-        if (sih.getSuperId() == previousScopedIdentifier.getId()) {
-          sih.setSuperId(newScopedIdentifier.getId());
-        }
-        if (sih.getSubId() == previousScopedIdentifier.getId()) {
-          sih.setSubId(newScopedIdentifier.getId());
-        }
-      });
-      MemberHandler.addHierarchyEntries(ctx, scopedIdentifierHierarchyList);
-    }
 
     return dataElementGroup.getIdentification();
   }

--- a/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/RecordHandler.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toList;
 import de.dataelementhub.dal.jooq.enums.ElementType;
 import de.dataelementhub.dal.jooq.enums.Status;
 import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifier;
-import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifierHierarchy;
 import de.dataelementhub.dal.jooq.tables.records.IdentifiedElementRecord;
 import de.dataelementhub.model.CtxUtil;
 import de.dataelementhub.model.dto.element.Element;
@@ -98,16 +97,8 @@ public class RecordHandler extends ElementHandler {
       throw new IllegalArgumentException();
     }
 
-    List<ScopedIdentifierHierarchy> scopedIdentifierHierarchyList = null;
-    final ScopedIdentifier previousScopedIdentifier;
-
     //update scopedIdentifier if status != DRAFT
-    if (previousRecord.getIdentification().getStatus() == Status.DRAFT) {
-      previousScopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx,
-          previousRecord.getIdentification().getUrn());
-      scopedIdentifierHierarchyList
-          = MemberHandler.getHierarchyEntries(ctx, previousScopedIdentifier);
-    } else {
+    if (previousRecord.getIdentification().getStatus() != Status.DRAFT) {
       ScopedIdentifier scopedIdentifier =
           IdentificationHandler.update(ctx, userId, record.getIdentification(),
               ElementHandler.getIdentifiedElementRecord(ctx, record.getIdentification()).getId());
@@ -115,25 +106,10 @@ public class RecordHandler extends ElementHandler {
 
       record.getIdentification().setNamespaceId(IdentificationHandler.getScopedIdentifier(ctx,
           previousRecord.getIdentification().getUrn()).getNamespaceId());
-      previousScopedIdentifier = null;
     }
 
     delete(ctx, userId, previousRecord.getIdentification().getUrn());
     create(ctx, userId, record);
-
-    if (scopedIdentifierHierarchyList != null) {
-      ScopedIdentifier newScopedIdentifier = IdentificationHandler.getScopedIdentifier(ctx,
-          record.getIdentification().getUrn());
-      scopedIdentifierHierarchyList.forEach(sih -> {
-        if (sih.getSuperId() == previousScopedIdentifier.getId()) {
-          sih.setSuperId(newScopedIdentifier.getId());
-        }
-        if (sih.getSubId() == previousScopedIdentifier.getId()) {
-          sih.setSubId(newScopedIdentifier.getId());
-        }
-      });
-      MemberHandler.addHierarchyEntries(ctx, scopedIdentifierHierarchyList);
-    }
 
     return record.getIdentification();
   }


### PR DESCRIPTION
**What's in the PR**
* revert the changes made in #79 for groups and records, since it is only necessary for dataelements (and causes bugs for groups/records)
* change equals/hashcode methods for Member to not include the status, but only urn and order
* close #80

**How to test manually**
* See issue description in #80 and check if problem is solved
