### PR TITLE
#83 - Creating a dataElement with valueDomainUrn that does not exist leads to 500 internal server error

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementHandler.java
@@ -55,8 +55,8 @@ public class DataElementHandler extends ElementHandler {
     } else if (dataElement.getValueDomainUrn() != null && !dataElement.getValueDomainUrn()
         .isEmpty()) {
       // If value domain urn is used, check if it is of an allowed type (enumerated or described vd)
-      Identification valueDomainIdentification =
-      IdentificationHandler.fromUrn(ctx, dataElement.getValueDomainUrn());
+      Identification valueDomainIdentification = IdentificationHandler.fromUrn(ctx,
+          dataElement.getValueDomainUrn());
       if (valueDomainIdentification == null) {
         throw new NoSuchElementException(
             "ValueDomainUrn: " + dataElement.getValueDomainUrn() + " does not exist!");

--- a/src/main/java/de/dataelementhub/model/handler/element/DataElementHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/element/DataElementHandler.java
@@ -55,8 +55,13 @@ public class DataElementHandler extends ElementHandler {
     } else if (dataElement.getValueDomainUrn() != null && !dataElement.getValueDomainUrn()
         .isEmpty()) {
       // If value domain urn is used, check if it is of an allowed type (enumerated or described vd)
-      ElementType elementType = IdentificationHandler.fromUrn(ctx, dataElement.getValueDomainUrn())
-          .getElementType();
+      Identification valueDomainIdentification =
+      IdentificationHandler.fromUrn(ctx, dataElement.getValueDomainUrn());
+      if (valueDomainIdentification == null) {
+        throw new NoSuchElementException(
+            "ValueDomainUrn: " + dataElement.getValueDomainUrn() + " does not exist!");
+      }
+      ElementType elementType = valueDomainIdentification.getElementType();
       if (elementType != ElementType.ENUMERATED_VALUE_DOMAIN
           && elementType != ElementType.DESCRIBED_VALUE_DOMAIN) {
         throw new IllegalArgumentException(


### PR DESCRIPTION
**What's in the PR**
* Return 404 not found if given valueDomainUrn does not exist

**How to test manually**
* Test with [Model - #70](https://github.com/mig-frankfurt/dataelementhub.rest/pull/70)
