### PR TITLE
#95 - Prevent multiple definitions of the same language

### DIFF
--- a/src/main/java/de/dataelementhub/model/service/ElementService.java
+++ b/src/main/java/de/dataelementhub/model/service/ElementService.java
@@ -65,6 +65,12 @@ public class ElementService {
         throw new IllegalStateException("Unreleased namespaces can't contain released elements");
       }
     }
+
+    if (hasDuplicateLanguageDefinitions(element)) {
+      throw new IllegalArgumentException(
+          "Your element contains multiple definitions of at least one language");
+    }
+
     switch (element.getIdentification().getElementType()) {
       case DATAELEMENT:
         return DataElementHandler.create(ctx, userId, (DataElement) element);
@@ -321,5 +327,21 @@ public class ElementService {
   public List<List<SimplifiedElementIdentification>> getElementPaths(
       DSLContext ctx, int userId, String urn, String languages) {
     return ElementPathHandler.getElementPaths(ctx, userId, urn, languages);
+  }
+
+  /**
+   * Check for duplicate languages in definitions.
+   */
+  private boolean hasDuplicateLanguageDefinitions(Element element) {
+    List<String> languages = new ArrayList<>();
+    boolean hasDuplicates = false;
+    for (Definition definition : element.getDefinitions()) {
+      if (languages.contains(definition.getLanguage().toLowerCase())) {
+        hasDuplicates = true;
+        break;
+      }
+      languages.add(definition.getLanguage().toLowerCase());
+    }
+    return hasDuplicates;
   }
 }


### PR DESCRIPTION
**What's in the PR**
* when creating an element, check if only one definition per language is present
* close #95 

**How to test manually**
* try to create an element with 2 or more definitions of the same language - this should now fail (you need to check this with dataelementhub-rest)