### PR TITLE
#100 - Prevent multiple definitions of the same language when updatin…

### DIFF
--- a/src/main/java/de/dataelementhub/model/service/ElementService.java
+++ b/src/main/java/de/dataelementhub/model/service/ElementService.java
@@ -235,6 +235,12 @@ public class ElementService {
         throw new IllegalStateException("Unreleased namespaces can't contain released elements");
       }
     }
+
+    if (hasDuplicateLanguageDefinitions(element)) {
+      throw new IllegalArgumentException(
+              "Your element contains multiple definitions of at least one language");
+    }
+
     Element previousElement = read(ctx, userId, element.getIdentification().getUrn());
     switch (element.getIdentification().getElementType()) {
       case DATAELEMENT:


### PR DESCRIPTION
**What's in the PR**
when updating an element, check if only one definition per language is present
close https://github.com/mig-frankfurt/dataelementhub.model/issues/100


**How to test manually**
try to update an element with 2 or more definitions of the same language - this should now fail (you need to check this with dataelementhub-rest)
