### PR TITLE
#119 - Definitions section is defined as object instead of array in t…

### DIFF
--- a/src/main/java/de/dataelementhub/model/handler/export/ExportHandler.java
+++ b/src/main/java/de/dataelementhub/model/handler/export/ExportHandler.java
@@ -94,7 +94,7 @@ public class ExportHandler {
         };
     jaxbMarshaller.setProperty(NAMESPACE_PREFIX_MAPPER, mapper);
     jaxbMarshaller.setProperty(JAXBContextProperties.MEDIA_TYPE, mediaType.toString());
-    jaxbMarshaller.setProperty(JAXBContextProperties.JSON_INCLUDE_ROOT, true);
+    jaxbMarshaller.setProperty(JAXBContextProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
     jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
     jaxbMarshaller.marshal(export, file);
     FileHandler.zip(file.getParent(), file.getParent() + "/" + timestamp


### PR DESCRIPTION
**What's in the PR**
* Use json wrapper as array name in the export files (JSON format)

**How to test manually**
* See #119
* close #119 